### PR TITLE
ci: Add HEAD of dependencies workflow

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -1,0 +1,103 @@
+name: HEAD of dependencies
+
+on:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-candidates:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade --pre .[test]
+
+    - name: List installed Python packages
+      run: python -m pip list
+
+    - name: Test with pytest
+      run: pytest
+
+  pyhf:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip uninstall --yes pyhf
+        python -m pip install --upgrade git+https://github.com/scikit-hep/pyhf.git
+
+    - name: List installed Python packages
+      run: python -m pip list
+
+    - name: Test with pytest
+      run: pytest
+
+  matplotlib:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip uninstall --yes matplotlib
+        # Need to use --extra-index-url as dependencies aren't on scipy-wheels-nightly package index.
+        # Need to use --pre as dev releases will need priority over stable releases.
+        python -m pip install \
+          --upgrade \
+          --pre \
+          --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+          matplotlib
+
+    - name: List installed Python packages
+      run: python -m pip list
+
+    - name: Test with pytest
+      run: pytest


### PR DESCRIPTION
* Add nightly tests for release candidates, the HEAD of pyhf on GitHub, and the nightly matplotlib wheels.