### PR TITLE
feat: Update to use pyhf v0.7.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ python_requires = >=3.7
 install_requires =
     numpy
     matplotlib
-    pyhf[contrib,minuit]>=0.7
+    pyhf[contrib,minuit]>=0.7.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Update to use `pyhf` `v0.7.0`+ and adopt the API changes since `pyhf` `v0.6.3`.

Resolves #28.

```
* Set lower bound of pyhf v0.7.0 in install_requires and remove upper bound on 
  jsonschema.
* Use pyhf v0.7.0+ API of model.config.par_names being a property attribute.
* Access model parameters by parameter name instead of fit result index.
```