### PR TITLE
Add feature: toy-based calculations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    jsonschema<4.15
     numpy
     matplotlib
     pyhf[contrib,minuit]>=0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     jsonschema<4.15
     numpy
     matplotlib
-    pyhf[contrib,minuit]<0.7
+    pyhf[contrib,minuit]>=0.7
 
 [options.extras_require]
 test =

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -92,9 +92,11 @@ class ABCD:
 
     @property
     def model(self):
-        return create_model(
-            self.signal_yields, self.signal_uncertainty, self.blinded
-        )
+        if not hasattr(self, '_model'):
+            setattr(self, '_model', create_model(
+                self.signal_yields, self.signal_uncertainty, self.blinded
+            ))
+        return getattr(self, '_model')
 
     @property
     def data(self):

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -149,13 +149,8 @@ class ABCD:
         numpy.ndarray
             Fit value for each parameter, optionally with its uncertainty
         """
-        pars = fixed_poi_fit(
-            poi_val=0,
-            data=self.data,
-            pdf=self.model,
-            init_pars=self.init_pars,
-            par_bounds=self.par_bounds,
-            fixed_params=self.fixed_params(bkg_only=True),
+        pars = self._fixed_poi_fit(
+            0,
             return_uncertainties=return_uncertainties,
         )
         return pars

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -243,6 +243,7 @@ class ABCD:
         poi_values, twice_nll_values = self.twice_nll()
         return plt.plot(poi_values, twice_nll_values)[0]
 
+    @functools.lru_cache()
     def _hypotest(self, poi_value, calctype='asymptotics', **kwargs):
         return pyhf.infer.hypotest(
             poi_value,

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -253,7 +253,7 @@ class ABCD:
         plt.xlabel(r'$\mu$')
         plt.xlim(
             0,
-            self.par_bounds[self.model.config.par_names().index(poi_name)][1],
+            self.par_bounds[self.model.config.par_names.index(poi_name)][1],
         )
         plt.ylabel(r'$-2 \ln L$')
         plt.ylim(0, 5)

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -22,12 +22,6 @@ from .pyhf_util import (
 )
 
 
-pyhf.set_backend(
-    pyhf.default_backend,
-    pyhf.optimize.scipy_optimizer(solver_options={'eps': 1e-6}),
-)
-
-
 class ABCD:
     """
     An ABCD plane, including yields in data and signal and systematic

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -22,7 +22,7 @@ from .pyhf_util import (
 )
 
 
-pyhf.set_backend(pyhf.default_backend, pyhf.optimize.scipy_optimizer(solver_options={'eps': 1e-7}))
+pyhf.set_backend(pyhf.default_backend, pyhf.optimize.scipy_optimizer(solver_options={'eps': 1e-6}))
 
 
 class ABCD:

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -89,15 +89,9 @@ class ABCD:
 
     @property
     def model(self):
-        if not hasattr(self, '_model'):
-            setattr(
-                self,
-                '_model',
-                create_model(
-                    self.signal_yields, self.signal_uncertainty, self.blinded
-                ),
-            )
-        return getattr(self, '_model')
+        return create_model(
+            self.signal_yields, self.signal_uncertainty, self.blinded
+        )
 
     @property
     def data(self):

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -237,6 +237,20 @@ class ABCD:
         poi_values, twice_nll_values = self.twice_nll()
         return plt.plot(poi_values, twice_nll_values)[0]
 
+    def _hypotest(self, poi_value, calctype='asymptotics', **kwargs):
+        return pyhf.infer.hypotest(
+            poi_value,
+            self.data,
+            self.model,
+            self.init_pars,
+            self.par_bounds,
+            self.fixed_params(),
+            calctype=calctype,
+            return_tail_probs=True,
+            return_expected_set=True,
+            **kwargs
+        )
+
     @functools.lru_cache()
     def _hypotest_scan(self, calctype='asymptotics', **kwargs):
         return hypotest_scan(

--- a/src/abcd_pyhf/abcd.py
+++ b/src/abcd_pyhf/abcd.py
@@ -22,7 +22,10 @@ from .pyhf_util import (
 )
 
 
-pyhf.set_backend(pyhf.default_backend, pyhf.optimize.scipy_optimizer(solver_options={'eps': 1e-6}))
+pyhf.set_backend(
+    pyhf.default_backend,
+    pyhf.optimize.scipy_optimizer(solver_options={'eps': 1e-6}),
+)
 
 
 class ABCD:
@@ -93,9 +96,13 @@ class ABCD:
     @property
     def model(self):
         if not hasattr(self, '_model'):
-            setattr(self, '_model', create_model(
-                self.signal_yields, self.signal_uncertainty, self.blinded
-            ))
+            setattr(
+                self,
+                '_model',
+                create_model(
+                    self.signal_yields, self.signal_uncertainty, self.blinded
+                ),
+            )
         return getattr(self, '_model')
 
     @property
@@ -297,7 +304,10 @@ class ABCD:
             Mu values and the corresponding CL_{s+b} values for each signal
             strength
         """
-        return self._hypotest_scan(calctype=calctype, **kwargs)[0], self._hypotest_scan(calctype=calctype, **kwargs)[2][0]
+        return (
+            self._hypotest_scan(calctype=calctype, **kwargs)[0],
+            self._hypotest_scan(calctype=calctype, **kwargs)[2][0],
+        )
 
     def clb(self, calctype='asymptotics', **kwargs):
         """
@@ -315,7 +325,10 @@ class ABCD:
             Mu values and the corresponding CL_b values for each signal
             strength
         """
-        return self._hypotest_scan(calctype=calctype, **kwargs)[0], self._hypotest_scan(calctype=calctype, **kwargs)[2][1]
+        return (
+            self._hypotest_scan(calctype=calctype, **kwargs)[0],
+            self._hypotest_scan(calctype=calctype, **kwargs)[2][1],
+        )
 
     def cls(self, calctype='asymptotics', **kwargs):
         """
@@ -358,7 +371,9 @@ class ABCD:
             Observed upper limit on mu and the expected upper limit band in the
             form: (-2 sigma, -1 sigma, median, +1 sigma, +2 sigma)
         """
-        poi, cls_observed, cls_expected_set = self.cls(calctype=calctype, **kwargs)
+        poi, cls_observed, cls_expected_set = self.cls(
+            calctype=calctype, **kwargs
+        )
         return poi_upper_limit(poi, cls_observed), [
             poi_upper_limit(poi, cls_expected)
             for cls_expected in cls_expected_set
@@ -379,6 +394,8 @@ class ABCD:
         pyhf.contrib.viz.brazil.BrazilBandCollection
             Artist containing the matplotlib.artist objects drawn
         """
-        mu, cls_observed, cls_expected_set = self.cls(calctype=calctype, **kwargs)
+        mu, cls_observed, cls_expected_set = self.cls(
+            calctype=calctype, **kwargs
+        )
         results = list(zip(cls_observed, cls_expected_set.T))
         return pyhf.contrib.viz.brazil.plot_results(mu, results)

--- a/src/abcd_pyhf/pool_utils.py
+++ b/src/abcd_pyhf/pool_utils.py
@@ -1,0 +1,10 @@
+from itertools import repeat
+
+
+def apply_args_and_kwargs(func, args, kwargs):
+    return func(*args, **kwargs)
+
+
+def starmap_with_kwargs(pool, func, iterable_args, iterable_kwargs):
+    iterable_for_starmap = zip(repeat(func), iterable_args, iterable_kwargs)
+    return pool.starmap(apply_args_and_kwargs, iterable_for_starmap)

--- a/src/abcd_pyhf/pyhf_util.py
+++ b/src/abcd_pyhf/pyhf_util.py
@@ -173,7 +173,15 @@ def get_fixed_params(model, bkg_only=False):
     return fixed_params
 
 
-def fixed_poi_fit(poi_val, data, pdf, init_pars, par_bounds, fixed_params, return_uncertainties):
+def fixed_poi_fit(
+    poi_val,
+    data,
+    pdf,
+    init_pars,
+    par_bounds,
+    fixed_params,
+    return_uncertainties,
+):
     if return_uncertainties:
         backend, original_optimizer = pyhf.get_backend()
         pyhf.set_backend(backend, pyhf.optimize.minuit_optimizer())
@@ -185,7 +193,7 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars, par_bounds, fixed_params, retur
         init_pars=init_pars,
         par_bounds=par_bounds,
         fixed_params=fixed_params,
-        return_uncertainties=return_uncertainties
+        return_uncertainties=return_uncertainties,
     )
 
     if return_uncertainties:
@@ -205,7 +213,7 @@ def fit(data, pdf, init_pars, par_bounds, fixed_params, return_uncertainties):
         init_pars=init_pars,
         par_bounds=par_bounds,
         fixed_params=fixed_params,
-        return_uncertainties=return_uncertainties
+        return_uncertainties=return_uncertainties,
     )
 
     if return_uncertainties:
@@ -256,10 +264,14 @@ def hypotest_scan(
         return_expected,
         return_expected_set,
     ]
-    starmap_args = zip(poi_values, *[[arg] * len(poi_values) for arg in other_args])
+    starmap_args = zip(
+        poi_values, *[[arg] * len(poi_values) for arg in other_args]
+    )
     starmap_kwargs = [kwargs] * len(poi_values)
     with multiprocessing.pool.Pool() as pool:
-        results = starmap_with_kwargs(pool, pyhf.infer.hypotest, starmap_args, starmap_kwargs)
+        results = starmap_with_kwargs(
+            pool, pyhf.infer.hypotest, starmap_args, starmap_kwargs
+        )
     cls_observed = []
     if return_tail_probs:
         tail_probs = []

--- a/src/abcd_pyhf/pyhf_util.py
+++ b/src/abcd_pyhf/pyhf_util.py
@@ -106,6 +106,7 @@ def get_init_pars(observed_yields, model):
         observed_yields[control_regions[1]] / background_normalization_estimate
     )
     init_pars = model.config.suggested_init()
+    init_pars[model.config.par_order.index(poi_name)] = 0
     init_pars[
         model.config.par_order.index(bkg_normalization_name)
     ] = background_normalization_estimate

--- a/src/abcd_pyhf/pyhf_util.py
+++ b/src/abcd_pyhf/pyhf_util.py
@@ -144,7 +144,7 @@ def get_par_bounds(observed_yields, model):
                 background_normalization_estimate
                 + 5 * math.sqrt(background_normalization_estimate)
             ),
-            5,
+            10,
         )
     poi_max = math.ceil(background_normalization_max)
     par_bounds = model.config.suggested_bounds()
@@ -171,6 +171,47 @@ def get_fixed_params(model, bkg_only=False):
             model.config.par_names().index(signal_uncertainty_name)
         ] = True
     return fixed_params
+
+
+def fixed_poi_fit(poi_val, data, pdf, init_pars, par_bounds, fixed_params, return_uncertainties):
+    if return_uncertainties:
+        backend, original_optimizer = pyhf.get_backend()
+        pyhf.set_backend(backend, pyhf.optimize.minuit_optimizer())
+
+    result = pyhf.infer.mle.fixed_poi_fit(
+        poi_val=poi_val,
+        data=data,
+        pdf=pdf,
+        init_pars=init_pars,
+        par_bounds=par_bounds,
+        fixed_params=fixed_params,
+        return_uncertainties=return_uncertainties
+    )
+
+    if return_uncertainties:
+        pyhf.set_backend(backend, original_optimizer)
+
+    return result
+
+
+def fit(data, pdf, init_pars, par_bounds, fixed_params, return_uncertainties):
+    if return_uncertainties:
+        backend, original_optimizer = pyhf.get_backend()
+        pyhf.set_backend(backend, pyhf.optimize.minuit_optimizer())
+
+    result = pyhf.infer.mle.fit(
+        data=data,
+        pdf=pdf,
+        init_pars=init_pars,
+        par_bounds=par_bounds,
+        fixed_params=fixed_params,
+        return_uncertainties=return_uncertainties
+    )
+
+    if return_uncertainties:
+        pyhf.set_backend(backend, original_optimizer)
+
+    return result
 
 
 def fixed_poi_fit_scan(

--- a/src/abcd_pyhf/pyhf_util.py
+++ b/src/abcd_pyhf/pyhf_util.py
@@ -168,7 +168,7 @@ def get_fixed_params(model, bkg_only=False):
     fixed_params = model.config.suggested_fixed()
     if bkg_only:
         fixed_params[
-            model.config.par_names().index(signal_uncertainty_name)
+            model.config.par_names.index(signal_uncertainty_name)
         ] = True
     return fixed_params
 

--- a/tests/test_ABCD.py
+++ b/tests/test_ABCD.py
@@ -265,3 +265,11 @@ def test_fixed_poi_fit_special_case():
         signal_uncertainty_special_case,
     )
     assert abcd._fixed_poi_fit(4) is not None
+
+
+def test_toys():
+    observed_yields_low = observed_yields.copy()
+    for key in observed_yields:
+        observed_yields_low[key] //= 10
+    abcd = ABCD(observed_yields_low, signal_yields, signal_uncertainty)
+    abcd._hypotest_scan(calctype='toybased', ntoys=10)

--- a/tests/test_ABCD.py
+++ b/tests/test_ABCD.py
@@ -141,6 +141,11 @@ def test_twice_nll_plot():
     assert abcd.twice_nll_plot() is not None
 
 
+def test_hypotest():
+    abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
+    abcd._hypotest(1)
+
+
 def test_hypotest_scan():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     abcd._hypotest_scan()
@@ -273,3 +278,25 @@ def test_toys():
         observed_yields_low[key] //= 10
     abcd = ABCD(observed_yields_low, signal_yields, signal_uncertainty)
     abcd._hypotest_scan(calctype='toybased', ntoys=10)
+
+
+def test_hypotest_special_case():
+    observed_yields_special_case = {
+        'A': 0,
+        'B': 15004,
+        'C': 441,
+        'D': 192036934,
+    }
+    signal_yields_special_case = {
+        'A': 0.13,
+        'B': 0.004,
+        'C': 0.00001,
+        'D': 0.00006,
+    }
+    signal_uncertainty_special_case = 0.02
+    abcd = ABCD(
+        observed_yields_special_case,
+        signal_yields_special_case,
+        signal_uncertainty_special_case,
+    )
+    abcd._hypotest(0)

--- a/tests/test_ABCD.py
+++ b/tests/test_ABCD.py
@@ -77,10 +77,21 @@ def test_fixed_poi_fit():
     observed_yields_copy['D'] += signal_yields['D']
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     fixed_poi_fit = abcd._fixed_poi_fit(signal_yields['A'])
-    assert fixed_poi_fit[abcd.model.config.par_names().index('mu')][0] == signal_yields['A']
-    assert math.isclose(fixed_poi_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0], 0, abs_tol=1e-1)
+    assert (
+        fixed_poi_fit[abcd.model.config.par_names().index('mu')][0]
+        == signal_yields['A']
+    )
     assert math.isclose(
-        fixed_poi_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2
+        fixed_poi_fit[
+            abcd.model.config.par_names().index('systematic_uncertainty')
+        ][0],
+        0,
+        abs_tol=1e-1,
+    )
+    assert math.isclose(
+        fixed_poi_fit[abcd.model.config.par_names().index('mu_b')][0],
+        observed_yields['A'],
+        rel_tol=1e-2,
     )
     assert math.isclose(
         fixed_poi_fit[abcd.model.config.par_names().index('tau_B')][0],
@@ -98,8 +109,17 @@ def test_bkg_only_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
     assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
-    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
-    assert math.isclose(bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2)
+    assert (
+        bkg_only_fit[
+            abcd.model.config.par_names().index('systematic_uncertainty')
+        ][0]
+        == 0
+    )
+    assert math.isclose(
+        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        observed_yields['A'],
+        rel_tol=1e-2,
+    )
     assert math.isclose(
         bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
@@ -115,14 +135,28 @@ def test_bkg_only_fit():
 def test_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     fit = abcd.fit()
-    assert math.isclose(fit[abcd.model.config.par_names().index('mu')][0], 0, abs_tol=1e-1)
-    assert math.isclose(fit[abcd.model.config.par_names().index('systematic_uncertainty')][0], 0, abs_tol=1e-1)
-    assert math.isclose(fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2)
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('tau_B')][0], observed_yields['B'] / observed_yields['A'], rel_tol=1e-2
+        fit[abcd.model.config.par_names().index('mu')][0], 0, abs_tol=1e-1
     )
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('tau_C')][0], observed_yields['C'] / observed_yields['A'], rel_tol=1e-2
+        fit[abcd.model.config.par_names().index('systematic_uncertainty')][0],
+        0,
+        abs_tol=1e-1,
+    )
+    assert math.isclose(
+        fit[abcd.model.config.par_names().index('mu_b')][0],
+        observed_yields['A'],
+        rel_tol=1e-2,
+    )
+    assert math.isclose(
+        fit[abcd.model.config.par_names().index('tau_B')][0],
+        observed_yields['B'] / observed_yields['A'],
+        rel_tol=1e-2,
+    )
+    assert math.isclose(
+        fit[abcd.model.config.par_names().index('tau_C')][0],
+        observed_yields['C'] / observed_yields['A'],
+        rel_tol=1e-2,
     )
 
 
@@ -195,9 +229,16 @@ def test_bkg_only_fit_very_small_expected_mu_b():
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
     assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
-    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
+    assert (
+        bkg_only_fit[
+            abcd.model.config.par_names().index('systematic_uncertainty')
+        ][0]
+        == 0
+    )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields_copy['A'], abs_tol=1e-1
+        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        observed_yields_copy['A'],
+        abs_tol=1e-1,
     )
     assert math.isclose(
         bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
@@ -233,9 +274,16 @@ def test_bkg_only_fit_special_case():
     )
     bkg_only_fit = abcd.bkg_only_fit()
     assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
-    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
+    assert (
+        bkg_only_fit[
+            abcd.model.config.par_names().index('systematic_uncertainty')
+        ][0]
+        == 0
+    )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields_special_case['A'], abs_tol=1e-1
+        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        observed_yields_special_case['A'],
+        abs_tol=1e-1,
     )
     assert math.isclose(
         bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],

--- a/tests/test_ABCD.py
+++ b/tests/test_ABCD.py
@@ -78,28 +78,28 @@ def test_fixed_poi_fit():
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     fixed_poi_fit = abcd._fixed_poi_fit(signal_yields['A'])
     assert (
-        fixed_poi_fit[abcd.model.config.par_names().index('mu')][0]
+        fixed_poi_fit[abcd.model.config.par_names.index('mu')][0]
         == signal_yields['A']
     )
     assert math.isclose(
         fixed_poi_fit[
-            abcd.model.config.par_names().index('systematic_uncertainty')
+            abcd.model.config.par_names.index('systematic_uncertainty')
         ][0],
         0,
         abs_tol=1e-1,
     )
     assert math.isclose(
-        fixed_poi_fit[abcd.model.config.par_names().index('mu_b')][0],
+        fixed_poi_fit[abcd.model.config.par_names.index('mu_b')][0],
         observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        fixed_poi_fit[abcd.model.config.par_names().index('tau_B')][0],
+        fixed_poi_fit[abcd.model.config.par_names.index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        fixed_poi_fit[abcd.model.config.par_names().index('tau_C')][0],
+        fixed_poi_fit[abcd.model.config.par_names.index('tau_C')][0],
         observed_yields['C'] / observed_yields['A'],
         rel_tol=1e-2,
     )
@@ -108,25 +108,25 @@ def test_fixed_poi_fit():
 def test_bkg_only_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names.index('mu')][0] == 0
     assert (
         bkg_only_fit[
-            abcd.model.config.par_names().index('systematic_uncertainty')
+            abcd.model.config.par_names.index('systematic_uncertainty')
         ][0]
         == 0
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('mu_b')][0],
         observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_C')][0],
         observed_yields['C'] / observed_yields['A'],
         rel_tol=1e-2,
     )
@@ -136,25 +136,25 @@ def test_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     fit = abcd.fit()
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('mu')][0], 0, abs_tol=1e-1
+        fit[abcd.model.config.par_names.index('mu')][0], 0, abs_tol=1e-1
     )
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('systematic_uncertainty')][0],
+        fit[abcd.model.config.par_names.index('systematic_uncertainty')][0],
         0,
         abs_tol=1e-1,
     )
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('mu_b')][0],
+        fit[abcd.model.config.par_names.index('mu_b')][0],
         observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('tau_B')][0],
+        fit[abcd.model.config.par_names.index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        fit[abcd.model.config.par_names().index('tau_C')][0],
+        fit[abcd.model.config.par_names.index('tau_C')][0],
         observed_yields['C'] / observed_yields['A'],
         rel_tol=1e-2,
     )
@@ -228,25 +228,25 @@ def test_bkg_only_fit_very_small_expected_mu_b():
     observed_yields_copy['D'] *= 1000
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names.index('mu')][0] == 0
     assert (
         bkg_only_fit[
-            abcd.model.config.par_names().index('systematic_uncertainty')
+            abcd.model.config.par_names.index('systematic_uncertainty')
         ][0]
         == 0
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('mu_b')][0],
         observed_yields_copy['A'],
         abs_tol=1e-1,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_B')][0],
         observed_yields_copy['D'] / observed_yields_copy['C'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_C')][0],
         observed_yields_copy['D'] / observed_yields_copy['B'],
         rel_tol=1e-2,
     )
@@ -273,25 +273,25 @@ def test_bkg_only_fit_special_case():
         signal_uncertainty_special_case,
     )
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names.index('mu')][0] == 0
     assert (
         bkg_only_fit[
-            abcd.model.config.par_names().index('systematic_uncertainty')
+            abcd.model.config.par_names.index('systematic_uncertainty')
         ][0]
         == 0
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('mu_b')][0],
         observed_yields_special_case['A'],
         abs_tol=1e-1,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_B')][0],
         observed_yields_special_case['D'] / observed_yields_special_case['C'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
+        bkg_only_fit[abcd.model.config.par_names.index('tau_C')][0],
         observed_yields_special_case['D'] / observed_yields_special_case['B'],
         rel_tol=1e-2,
     )

--- a/tests/test_ABCD.py
+++ b/tests/test_ABCD.py
@@ -77,18 +77,18 @@ def test_fixed_poi_fit():
     observed_yields_copy['D'] += signal_yields['D']
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     fixed_poi_fit = abcd._fixed_poi_fit(signal_yields['A'])
-    assert fixed_poi_fit[0][0] == signal_yields['A']
-    assert math.isclose(fixed_poi_fit[1][0], 0, abs_tol=1e-1)
+    assert fixed_poi_fit[abcd.model.config.par_names().index('mu')][0] == signal_yields['A']
+    assert math.isclose(fixed_poi_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0], 0, abs_tol=1e-1)
     assert math.isclose(
-        fixed_poi_fit[2][0], observed_yields['A'], rel_tol=1e-2
+        fixed_poi_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2
     )
     assert math.isclose(
-        fixed_poi_fit[3][0],
+        fixed_poi_fit[abcd.model.config.par_names().index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        fixed_poi_fit[4][0],
+        fixed_poi_fit[abcd.model.config.par_names().index('tau_C')][0],
         observed_yields['C'] / observed_yields['A'],
         rel_tol=1e-2,
     )
@@ -97,16 +97,16 @@ def test_fixed_poi_fit():
 def test_bkg_only_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[0][0] == 0
-    assert bkg_only_fit[1][0] == 0
-    assert math.isclose(bkg_only_fit[2][0], observed_yields['A'], rel_tol=1e-2)
+    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
+    assert math.isclose(bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2)
     assert math.isclose(
-        bkg_only_fit[3][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
         observed_yields['B'] / observed_yields['A'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[4][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
         observed_yields['C'] / observed_yields['A'],
         rel_tol=1e-2,
     )
@@ -115,14 +115,14 @@ def test_bkg_only_fit():
 def test_fit():
     abcd = ABCD(observed_yields, signal_yields, signal_uncertainty)
     fit = abcd.fit()
-    assert math.isclose(fit[0][0], 0, abs_tol=1e-1)
-    assert math.isclose(fit[1][0], 0, abs_tol=1e-1)
-    assert math.isclose(fit[2][0], observed_yields['A'], rel_tol=1e-2)
+    assert math.isclose(fit[abcd.model.config.par_names().index('mu')][0], 0, abs_tol=1e-1)
+    assert math.isclose(fit[abcd.model.config.par_names().index('systematic_uncertainty')][0], 0, abs_tol=1e-1)
+    assert math.isclose(fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields['A'], rel_tol=1e-2)
     assert math.isclose(
-        fit[3][0], observed_yields['B'] / observed_yields['A'], rel_tol=1e-2
+        fit[abcd.model.config.par_names().index('tau_B')][0], observed_yields['B'] / observed_yields['A'], rel_tol=1e-2
     )
     assert math.isclose(
-        fit[4][0], observed_yields['C'] / observed_yields['A'], rel_tol=1e-2
+        fit[abcd.model.config.par_names().index('tau_C')][0], observed_yields['C'] / observed_yields['A'], rel_tol=1e-2
     )
 
 
@@ -189,18 +189,18 @@ def test_bkg_only_fit_very_small_expected_mu_b():
     observed_yields_copy['D'] *= 1000
     abcd = ABCD(observed_yields_copy, signal_yields, signal_uncertainty)
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[0][0] == 0
-    assert bkg_only_fit[1][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
     assert math.isclose(
-        bkg_only_fit[2][0], observed_yields_copy['A'], abs_tol=1e-1
+        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields_copy['A'], abs_tol=1e-1
     )
     assert math.isclose(
-        bkg_only_fit[3][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
         observed_yields_copy['D'] / observed_yields_copy['C'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[4][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
         observed_yields_copy['D'] / observed_yields_copy['B'],
         rel_tol=1e-2,
     )
@@ -227,18 +227,18 @@ def test_bkg_only_fit_special_case():
         signal_uncertainty_special_case,
     )
     bkg_only_fit = abcd.bkg_only_fit()
-    assert bkg_only_fit[0][0] == 0
-    assert bkg_only_fit[1][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names().index('mu')][0] == 0
+    assert bkg_only_fit[abcd.model.config.par_names().index('systematic_uncertainty')][0] == 0
     assert math.isclose(
-        bkg_only_fit[2][0], observed_yields_special_case['A'], abs_tol=1e-1
+        bkg_only_fit[abcd.model.config.par_names().index('mu_b')][0], observed_yields_special_case['A'], abs_tol=1e-1
     )
     assert math.isclose(
-        bkg_only_fit[3][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_B')][0],
         observed_yields_special_case['D'] / observed_yields_special_case['C'],
         rel_tol=1e-2,
     )
     assert math.isclose(
-        bkg_only_fit[4][0],
+        bkg_only_fit[abcd.model.config.par_names().index('tau_C')][0],
         observed_yields_special_case['D'] / observed_yields_special_case['B'],
         rel_tol=1e-2,
     )


### PR DESCRIPTION
Also bumps `pyhf` version requirement up to `>=0.7`. Resolves #15 and #28.